### PR TITLE
Adds exception thrown by execute() method

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -76,6 +76,7 @@ jobs:
       matrix:
         php-version:
           - "7.4"
+          - "8.0"
 
     services:
       oracle:
@@ -125,6 +126,7 @@ jobs:
       matrix:
         php-version:
           - "7.4"
+          - "8.0"
 
     services:
       oracle:
@@ -315,7 +317,6 @@ jobs:
       matrix:
         php-version:
           - "7.4"
-          - "8.0"
         mysql-version:
           - "5.7"
           - "8.0"
@@ -344,6 +345,16 @@ jobs:
             php-version: "7.4"
             mysql-version: "8.0"
             extension: "mysqli"
+          - php-version: "8.0"
+            mysql-version: "8.0"
+            extension: "mysqli"
+            custom-entrypoint: >-
+              --entrypoint sh mysql:8 -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
+          - php-version: "8.0"
+            mysql-version: "8.0"
+            extension: "pdo_mysql"
+            custom-entrypoint: >-
+              --entrypoint sh mysql:8 -c "exec docker-entrypoint.sh mysqld --default-authentication-plugin=mysql_native_password"
 
     services:
       mysql:
@@ -405,6 +416,7 @@ jobs:
         php-version:
           - "7.3"
           - "7.4"
+          - "8.0"
         extension:
           - "sqlsrv"
           - "pdo_sqlsrv"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -445,7 +445,7 @@ jobs:
           coverage: "pcov"
           ini-values: "zend.assertions=1"
           tools: "pecl"
-          extensions: "${{ matrix.extension }}-5.7.0preview"
+          extensions: "${{ matrix.extension }}-5.9.0preview1"
 
       - name: "Cache dependencies installed with composer"
         uses: "actions/cache@v2"

--- a/lib/Doctrine/DBAL/Query/QueryBuilder.php
+++ b/lib/Doctrine/DBAL/Query/QueryBuilder.php
@@ -4,6 +4,7 @@ namespace Doctrine\DBAL\Query;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\ResultStatement;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\Expression\CompositeExpression;
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
@@ -200,6 +201,8 @@ class QueryBuilder
      * Executes this query using the bound parameters and their types.
      *
      * @return ResultStatement|int
+     *
+     * @throws Exception
      */
     public function execute()
     {

--- a/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
+++ b/tests/Doctrine/Tests/DBAL/Driver/OCI8/OCI8StatementTest.php
@@ -25,6 +25,7 @@ class OCI8StatementTest extends DbalTestCase
      * @param mixed[] $params
      *
      * @dataProvider executeDataProvider
+     * @requires PHP < 8.0
      */
     public function testExecute(array $params): void
     {


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement (minor)
| BC Break     | no
| Fixed issues | n/a

#### Summary

My IDE was telling me I was trying to catch a non-existent exception, however it's clear by digging down a level that the Exception is throw by this class, so this simply annotates that.

Perhaps this should catch it and throw a QueryException?  Happy to update if it should be.  Please just let me know.

Also, I raised this against the 2.12 branch which is the latest branch I could find this file in, as I'm currently using 2.11.1.  I hope this was OK?
